### PR TITLE
Add minimum Perl version (PRC)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
     PL_FILES          => {},
     ABSTRACT_FROM     => 'lib/Regexp/Common/time.pm',
     AUTHOR            => 'Eric J. Roode <eroode@barrack.com>',
+    MIN_PERL_VERSION  => '5.6.0',
     META_MERGE        => {
       "meta-spec" => { version => 2 },
       resources => {


### PR DESCRIPTION
Add the minimum required Perl version to `Makefile.PL`, to get rid of the CPANTS warning.

This is a PRC contribution.
