### PR TITLE
Accept second fractions in ISO date time strings (PRC)

### DIFF
--- a/lib/Regexp/Common/time.pm
+++ b/lib/Regexp/Common/time.pm
@@ -747,11 +747,11 @@ pattern name => ['time', 'iso'],
     qq/(?k:/,
     qq/(?=\\d)/,     # Expect a digit
     qq/(?:/,         # Begin optional date portion
-        qq/(?k:$master{yr4})/,   $m2middle,   qq/(?k:$master{dy2})/,
+        qq/(?k:$master{yr4})/, qq/(?:-)(?k:$master{mo2})(?:-)/, qq/(?k:$master{dy2})/,
     qq/)?/,          # End optional date portion
     $dt_sep,
     qq/(?:/,         # Begin optional time portion
-        qq/(?k:$master{hr2})/,  $min2middle,  qq/(?k:$master{sc2})/,
+        qq/(?k:$master{hr2})/, qq/(?::)(?k:$master{mi2})(?::)/, qq/(?k:$master{sc2})/,
     qq/)?)/;         # End optional time portion
 
 pattern name => ['time', 'mail'],

--- a/lib/Regexp/Common/time.pm
+++ b/lib/Regexp/Common/time.pm
@@ -751,7 +751,7 @@ pattern name => ['time', 'iso'],
     qq/)?/,          # End optional date portion
     $dt_sep,
     qq/(?:/,         # Begin optional time portion
-        qq/(?k:$master{hr2})/, qq/(?::)(?k:$master{mi2})(?::)/, qq/(?k:$master{sc2})/,
+        qq/(?k:$master{hr2})/, qq/(?::)(?k:$master{mi2})(?::)/, qq/(?k:$master{sc2}(?:\.\\d+)?)/,
     qq/)?)/;         # End optional time portion
 
 pattern name => ['time', 'mail'],

--- a/lib/Regexp/Common/time.pm
+++ b/lib/Regexp/Common/time.pm
@@ -752,7 +752,9 @@ pattern name => ['time', 'iso'],
     $dt_sep,
     qq/(?:/,         # Begin optional time portion
         qq/(?k:$master{hr2})/, qq/(?::)(?k:$master{mi2})(?::)/, qq/(?k:$master{sc2}(?:\.\\d+)?)/,
-    qq/)?)/;         # End optional time portion
+    qq/)?/,          # End optional time portion
+    qq/(?k:$master{tz})?/, # Optional time zone portion
+    qq/)/;
 
 pattern name => ['time', 'mail'],
     create => join '',

--- a/t/iso.t
+++ b/t/iso.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use Test::More tests => 8;
+
+use Regexp::Common 'time';
+
+my $time = '2015-09-19T00:15:20.373610+02:00';
+my @out = $time =~ /$RE{time}{iso}{-keep}/;
+
+is $out[0], $time, 'Matched all components';
+is $out[1], '2015',      'Year';
+is $out[2], '09',        'Month';
+is $out[3], '19',        'Day';
+is $out[4], '00',        'Hour';
+is $out[5], '15',        'Minute';
+is $out[6], '20.373610', 'Second';
+is $out[7], '+02:00',    'Time-zone';


### PR DESCRIPTION
Fixes RT [#107238](https://rt.cpan.org/Public/Bug/Display.html?id=107238).

Additionally, this PR further restricts the valid separators to only `-` and `:` for dates and times respectively, and adds time-zone in the time field. Please feel free to cherry pick the changes you think most suitable.

This is a PRC contribution.
